### PR TITLE
Inform listeners after loading last known geo position

### DIFF
--- a/src/app/pages/map/map.page.ts
+++ b/src/app/pages/map/map.page.ts
@@ -338,17 +338,15 @@ export class MapPage implements OnInit {
   }
 
   private async initPositionWatch() {
-    await this.focusLastKnownPosition();
+    const { timestamp, coords } =
+      await this.geolocation.loadLastKnownPosition();
+    if (timestamp !== -1) {
+      this.mapService.focus(coords.longitude, coords.latitude, 15);
+    }
+
     await this.geolocation.watchPosition((pos) => {
       this.onPositionChanged(pos);
     });
-  }
-
-  private async focusLastKnownPosition() {
-    const pos = await this.geolocation.loadLastKnownPosition();
-    if (pos.timestamp !== -1) {
-      this.mapService.focus(pos.coords.longitude, pos.coords.latitude, 15);
-    }
   }
 
   private initSettingsListeners() {


### PR DESCRIPTION
After successfully loading the last known position from storage, the map focuses this position. Other components (e.g. the boat layer) haven't received this position so far. As a consequence, they displayed wrong coordinates until the next position update triggered the event listeners.
Now all position watch listeners are called after the last known position was read from storage. Thus, all components are informed about the latest position.